### PR TITLE
Check for valid cname when sync'ing

### DIFF
--- a/ldap_sync/management/commands/syncldap.py
+++ b/ldap_sync/management/commands/syncldap.py
@@ -62,6 +62,13 @@ class Command(NoArgsCommand):
 
         for ldap_user in ldap_users:
             # Extract user attributes from LDAP response
+            
+            # Check to see if this user has valid cname. 
+            (cname, attribs) = ldap_user
+            if cname == None:
+                logger.warning("User is missing CNAME, skipping")
+                continue
+            
             user_attr = {}
             for (name, attr) in ldap_user[1].items():
                 user_attr[attributes[name]] = attr[0].decode('utf-8')


### PR DESCRIPTION
When using this to sync an ActiveDirectory, I found that some queries would pull 'users' that had no CNAMES, which causes the items() call to fail. This check allows the synchronization to complete by catching and skipping these cases. Might be useful for others.
